### PR TITLE
WIP: An attempt to support multiple paths in jenkins external ingress.

### DIFF
--- a/stable/jenkins/templates/jenkins-master-external-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-external-ingress.yaml
@@ -11,13 +11,18 @@ spec:
   rules:
   - host: {{ .Values.Master.ExternalHostName | quote }}
     http:
-      paths:
+      {{- if .Values.Master.ExternalIngress.Paths }}
+      {{- range .Values.Master.ExternalIngress.Paths }}
       - backend:
           serviceName: {{ template "jenkins.fullname" . }}
           servicePort: {{ .Values.Master.ServicePort }}
-        {{- if .Values.Master.ExternalIngress.BackendPath }}
-        path: {{ .Values.Master.ExternalIngress.BackendPath }}
-        {{- end }}
+        path: {{ . }}
+      {{- end }}
+      {{- else }}
+      - backend:
+          serviceName: {{ template "jenkins.fullname" . }}
+          servicePort: {{ .Values.Master.ServicePort }}
+      {{- end }}
 {{- if .Values.Master.ExternalIngress.TLS }}
   tls:
 {{ toYaml .Values.Master.ExternalIngress.TLS | indent 4 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -79,7 +79,9 @@ Master:
     Annotations:
     # kubernetes.io/ingress.class: nginx-external
     # kubernetes.io/tls-acme: "true"
-  # BackendPath: /some-path
+  # Paths:
+  # - /path-1
+  # - /path-2
 
 Agent:
   Enabled: true


### PR DESCRIPTION
This is an attempt to support multiple paths in an ingress. This is required when you want to expose selected paths in an external ingress, instead of the entire service. In this case, we want to expose only the endpoints for:
- `/github-webhooks`
- `/ghprbhook`
to the public rather than the entire Jenkins service.

However, I am limited by the template syntax for helm charts where I cannot refer any variable outside the list items within a `{{- range ...}}...{{- end }}` block.